### PR TITLE
feat: add container watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Kernel modules
+*.ko
+*.o
+*.mod
+*.cmd
+
 ### VisualStudioCode template
 .vscode/*
 !.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Kernel modules
 *.ko
 *.o
-*.mod
+*.mod.*
 *.cmd
+*.symvers
+*.order
 
 ### VisualStudioCode template
 .vscode/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "utils/cadvisor-lite"]
+	path = utils/cadvisor-lite
+	url = https://github.com/yidoyoon/cadvisor-lite.git

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,22 @@
 obj-m += metric.o
 
-all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+GO_FILES=$(shell pwd)/util/main.go
+EXECUTABLE_NAME=watcher
+TMP=container_info
+
+all: build_module build_go
+
+build_module:
+	make -C /lib/modules/$(shell uname -r) M=$(shell pwd) modules
+
+build_go:
+	@if [ ! -f go.mod ]; then \
+		go mod init github.com/yidoyoon/ebpf-mon; \
+	fi
+	go mod tidy
+	go build -o $(shell pwd)/$(EXECUTABLE_NAME) $(GO_FILES)
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r) M=$(shell pwd) clean
+	rm -f $(shell pwd)/$(EXECUTABLE_NAME)
+	rm -f $(shell pwd)/$(TMP)

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,37 @@
 obj-m += metric.o
 
-GO_FILES=$(shell pwd)/util/main.go
-EXECUTABLE_NAME=watcher
-TMP=container_info
+WATCHER_SRC=$(shell pwd)/watcher/watcher.go
+WATCHER_BIN=$(shell pwd)/watcher/watcher
+PERF_STAT_SRC=$(shell pwd)/utils/read_proc/read_proc.go
+PERF_STAT_BIN=$(shell pwd)/utils/read_proc/read_proc
+CONTAINER_INFO=$(shell pwd)/container_info
 
-all: build_module build_go
+build: build_module build_watcher
+setup_benchmark: build_cadvisor_lite build_module build_watcher
 
 build_module:
 	make -C /lib/modules/$(shell uname -r) M=$(shell pwd) modules
 
-build_go:
+build_watcher:
 	@if [ ! -f go.mod ]; then \
 		go mod init github.com/yidoyoon/ebpf-mon; \
 	fi
 	go mod tidy
-	go build -o $(shell pwd)/$(EXECUTABLE_NAME) $(GO_FILES)
+	go build -o $(WATCHER_BIN) $(WATCHER_SRC)
+
+build_cadvisor_lite:
+	@ifeq [ $(wildcard ./cadvisor-lite/.*), ]
+		$(MAKE) -C ./cadvisor-lite build
+	@else
+		@echo "Please clone submodule with below command first."
+		@echo "git submodule update --init"
+
+#build_perf_stat:
+#	go build -o $(PERF_STAT_BIN) $(PERF_STAT_SRC)
 
 clean:
 	make -C /lib/modules/$(shell uname -r) M=$(shell pwd) clean
-	rm -f $(shell pwd)/$(EXECUTABLE_NAME)
-	rm -f $(shell pwd)/$(TMP)
+	rm -f $(WATCHER_BIN)
+	rm -f $(CONTAINER_INFO)
+
+.PHONY: clean

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -1,0 +1,71 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+)
+
+func GetAllContainers() []types.Container {
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		panic(err)
+	}
+
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
+
+	return containers
+}
+
+func IsDockerInstalled() bool {
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = cli.ServerVersion(ctx)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func CreateTestContainer(count int) {
+	var wg sync.WaitGroup
+	for i := 1; i <= count; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			containerName := "busybox-ebpfmon" + strconv.Itoa(i)
+			_, err := exec.Command("sh", "-c", "docker run -itd --rm --name "+containerName+" busybox").Output()
+			if err != nil {
+				fmt.Printf("Failed to create container: %v\n", err)
+			} else {
+				fmt.Printf("Successfully created container: %s\n", containerName)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	fmt.Println("Wait for containers are initialized...")
+	time.Sleep(5 * time.Second)
+}
+
+func InputCount() int {
+	fmt.Println("Enter the number of docker containers(busybox) to create: ")
+	var containerCount int
+	_, err := fmt.Scan(&containerCount)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return containerCount
+}

--- a/util/main.go
+++ b/util/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type PidName struct {
+	pid  string
+	name string
+}
+
+var (
+	beforeHash string
+	newHash    string
+)
+
+func SetupSignalHandling() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGABRT, syscall.SIGSEGV)
+	go func() {
+		sig := <-c
+		switch sig {
+		case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGABRT, syscall.SIGSEGV:
+			exec.Command("sh", "-c", "rmmod metric.ko").Output()
+			fmt.Printf("%s received, stopping module and program will exit.\n", sig)
+			os.Exit(0)
+		case syscall.SIGILL, syscall.SIGFPE, syscall.SIGPIPE:
+			fmt.Printf("An internal error occurred: %s, program will exit.\n", sig)
+			os.Exit(1)
+		default:
+			fmt.Printf("Please stop the program using Ctrl+C.\n")
+		}
+	}()
+}
+
+func timePrint(msg string) {
+	now := time.Now()
+	fmt.Println(now.Format("01-02 15:04:05") + "\t" + msg)
+}
+
+func InsertModule(pidName []PidName) {
+	pidLen := len(pidName) - 1
+	if pidLen == 0 {
+		fmt.Println("There are no running containers in the current namespace.\nRemoving the module.")
+		_, err := exec.Command("sh", "-c", "rmmod metric.ko").Output()
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	var pids string
+	var names string
+
+	for _, pair := range pidName[:pidLen] {
+		pids += pair.pid + string(',')
+		names += pair.name + string(',')
+	}
+
+	_, err := exec.Command("sh", "-c", "rmmod metric.ko").Output()
+	if err != nil {
+		log.Println(err)
+	}
+
+	cmd := "insmod metric.ko pid=" + pids[:len(pids)-1] + " pid_count=" + fmt.Sprint(pidLen) + " container_name=" + names[:len(names)-1]
+
+	_, err = exec.Command("sh", "-c", cmd).Output()
+	if err != nil {
+		log.Println(err)
+	}
+
+	timePrint("[INFO] Container count(s) : " + fmt.Sprint(pidLen))
+}
+
+func ContainerChangeDetector(wg *sync.WaitGroup) {
+	defer wg.Done()
+	containerData := "./.container_info"
+	var pidName []PidName
+
+	for {
+		exec.Command("sh", "-c", "docker ps -q|xargs docker inspect --format '{{.State.Pid}},{{.ID}},{{.Name}}' > "+containerData).Output()
+		data, _ := os.ReadFile(containerData)
+		newHash = GetHash(string(data))
+		if beforeHash != newHash {
+			trimmedData := strings.TrimSpace(string(data))
+			containerList := strings.Split(trimmedData, "\n")
+			for _, container := range containerList {
+				slice := strings.Split(container, ",")
+				pidName = append(pidName, PidName{slice[0], slice[2]})
+			}
+			InsertModule(pidName)
+
+			beforeHash = newHash
+			timePrint("[INFO] Container list has been updated")
+			pidName = pidName[:0]
+		}
+	}
+}
+
+func GetHash(text string) string {
+	hash := md5.Sum([]byte(text))
+	return hex.EncodeToString(hash[:])
+}
+
+func InitWatcher() {
+	timePrint("[INFO] Initialize Watcher...")
+	var pidName []PidName
+
+	containerData := "./.container_info"
+	exec.Command("sh", "-c", "docker ps -q|xargs docker inspect --format '{{.State.Pid}},{{.ID}},{{.Name}}' > "+containerData).Output()
+	data, _ := os.ReadFile(containerData)
+	trimmedData := strings.TrimSpace(string(data))
+	containerList := strings.Split(trimmedData, "\n")
+	for _, container := range containerList {
+		slice := strings.Split(container, ",")
+		pidName = append(pidName, PidName{slice[0], slice[2]})
+	}
+	InsertModule(pidName)
+}
+
+func CreateTestContainer() {
+	fmt.Println("How many containers(busybox)?: ")
+	var count int
+	var discard string
+	fmt.Scanf("%d\n", &count)
+	fmt.Scanln(&discard)
+	for i := 0; i < count; i++ {
+		exec.Command("sh", "-c", "docker run -dt ubuntu").Output()
+	}
+}
+
+func main() {
+	SetupSignalHandling()
+	fmt.Println("Do you want to create some dummy containers? (y/N)")
+	var command string
+	_, err := fmt.Scanln(&command)
+
+	for err != nil {
+		fmt.Println("The input is not valid. Please type 'y' for yes, 'N' for no.")
+		_, err = fmt.Scanln(&command)
+	}
+	if command == "Y" || command == "y" {
+		CreateTestContainer()
+	}
+
+	InitWatcher()
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go ContainerChangeDetector(&wg)
+	wg.Wait()
+}

--- a/utils/read_proc/read_proc.go
+++ b/utils/read_proc/read_proc.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hodgesds/perf-utils"
+	"io"
+	"log"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("cat", "/proc/metric")
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	getStats := func() error {
+		cmd := exec.Command("cat", "/proc/metric")
+		_, err := cmd.Output()
+		return err
+	}
+
+	cpuInstructions, _ := perf.CPUInstructions(getStats)
+	cpuCycles, _ := perf.CPUCycles(getStats)
+	cacheRef, _ := perf.CacheRef(getStats)
+	cacheMiss, _ := perf.CacheMiss(getStats)
+	cpuRefCycles, _ := perf.CPURefCycles(getStats)
+	cpuClock, _ := perf.CPUClock(getStats)
+	cpuTaskClock, _ := perf.CPUTaskClock(getStats)
+	pageFaults, _ := perf.PageFaults(getStats)
+	contextSwitches, _ := perf.ContextSwitches(getStats)
+	minorPageFaults, _ := perf.MinorPageFaults(getStats)
+	majorPageFaults, _ := perf.MajorPageFaults(getStats)
+
+	fmt.Println(cpuInstructions.Value, cpuCycles.Value, cacheRef.Value, cacheMiss.Value, cpuRefCycles.Value, cpuClock.Value, cpuTaskClock.Value, pageFaults.Value, contextSwitches.Value, minorPageFaults.Value, majorPageFaults.Value)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintln(io.Discard, string(output))
+}


### PR DESCRIPTION
Add watcher
- Watcher controlls Linux kernel module in background.
- It detects changes in the state of the container being monitored, such as start or termination, and reloads the kernel module accordingly.
- Add a target for Makefile to build the watcher.

Add cadvisor-lite submodule
- Add 'cadvisor-lite' submodule for performance comparison with Linux kernel module.
- In order to increase the reliability of the performance comparison, 'cadvisor-lite' has been modified not to collect unnecessary resource usage, and only collects memory metrics for currently running Docker containers.